### PR TITLE
Update server dependencies

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -12,9 +12,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<output_directory>target</output_directory>
 		<jdk.version>1.8</jdk.version>
-		<jetty.version>9.4.12.v20180830</jetty.version>
-		<jersey.version>2.27</jersey.version>
-		<slf4j.version>1.7.25</slf4j.version>
+		<jetty.version>9.4.17.v20190418</jetty.version>
+		<jersey.version>2.28</jersey.version>
+		<slf4j.version>1.7.26</slf4j.version>
 	</properties>
 
 	<build>
@@ -111,12 +111,12 @@
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>2.9.0</version>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-configuration2</artifactId>
-			<version>2.3</version>
+			<version>2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Update server dependencies including update of vulnerable version of jetty-server.
```
org.apache.commons:commons-configuration2 .......................... 2.3 -> 2.4
org.eclipse.jetty:jetty-server ........... 9.4.12.v20180830 -> 9.4.17.v20190418
org.eclipse.jetty:jetty-servlet ...........9.4.12.v20180830 -> 9.4.17.v20190418
org.glassfish.jersey.containers:jersey-container-jetty-servlet ... 2.27 -> 2.28
org.glassfish.jersey.core:jersey-server .......................... 2.27 -> 2.28
org.glassfish.jersey.inject:jersey-hk2 ........................... 2.27 -> 2.28
org.slf4j:slf4j-api .......................................... 1.7.25 -> 1.7.26
org.slf4j:slf4j-simple ....................................... 1.7.25 -> 1.7.26
redis.clients:jedis ............................................ 2.9.0 -> 3.0.1
```