### PR TITLE
Don't build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 os:
   - linux
-  - osx
 
 jdk:
   - oraclejdk9


### PR DESCRIPTION
Don't build on multiple Java versions on macOS.
From the Travis CI docs: `Note that testing against multiple Java versions is not supported on macOS`.